### PR TITLE
Add watchtower quadlet container

### DIFF
--- a/quadlet/watchtower/README.md
+++ b/quadlet/watchtower/README.md
@@ -1,0 +1,14 @@
+# Watchtower
+
+[Watchtower](https://github.com/containrrr/watchtower) provides a container that
+monitors other containers for updates. From their GitHub
+[README](https://github.com/containrrr/watchtower#readme):
+
+> With watchtower you can update the running version of your containerized app simply by
+> pushing a new image to the Docker Hub or your own image registry.
+
+> Watchtower will pull down your new image, gracefully shut down your existing container
+> and restart it with the same options that were used when it was deployed initially.
+> Run the watchtower container with the following command:
+
+There's also a [blog post](https://major.io/p/podman-quadlet-watchtower/) explaining how to run it as a quadlet with podman on Fedora CoreOS.

--- a/quadlet/watchtower/watchtower.container
+++ b/quadlet/watchtower/watchtower.container
@@ -1,0 +1,17 @@
+# Source: https://major.io/p/podman-quadlet-watchtower/
+# NOTE: Mounting podman socket + SecurityLabelDisable have security implications!
+[Unit]
+Description=Watchtower container updater
+Wants=network-online.target
+After=network-online.target
+
+[Container]
+ContainerName=watchtower
+Image=ghcr.io/containrrr/watchtower
+Environment=WATCHTOWER_CLEANUP=true
+Environment=WATCHTOWER_POLL_INTERVAL=3600
+Volume=/var/run/docker.sock:/var/run/docker.sock
+SecurityLabelDisable=true
+
+[Install]
+WantedBy=multi-user.target default.target


### PR DESCRIPTION
This example contains a watchtower container that will keep containers updated, much like podman's built-in auto-update, but it works in more places.

Was asked to bring this over here from a [Mastodon thread](https://hachyderm.io/@jorge/110463884532152569).