### PR TITLE
add sample Minio + Prometheus Quadlets

### DIFF
--- a/quadlet/minio-prometheus/README.md
+++ b/quadlet/minio-prometheus/README.md
@@ -1,0 +1,41 @@
+# Minio + Prometheus
+
+Use this example to provision a [Minio](https://min.io/) container with [Prometheus](https://prometheus.io/) metrics enabled.
+
+Minio is an open source S3 compatible object storage server which allows you to store objects on your filesystem and interact with them as if they were stored on S3.
+
+
+## Usage
+
+This example expects to be ran as a non-root user without the need for any special privileges.  It is not designed to be used in a production environment as credentials are hard-coded and stored in plain text, without any sort of encryption.  Please refer to the [Minio documentation](https://min.io/docs/minio/container/index.html) for more information on how to properly secure your Minio server.
+
+To run this example, you can move the files in this directory to your `~/.config/containers/systemd` directory, and run the following commands:
+
+```bash
+$ systemctl --user daemon-reload
+$ systemctl --user start prometheus.service
+$ systemctl --user start minio.service
+$ xdg-open http://localhost:9001
+```
+
+The default credentials are `admin:password` and all data is stored in `$HOME/.local/share/minio-data`.
+
+To interact with the Minio server using the [AWS CLI](https://aws.amazon.com/cli/), you must first login to the site and create an access key.  After you have created the access key, run the following command to configure the AWS CLI with your generated credentials:
+
+```bash
+$ aws configure --profile minio
+AWS Access Key ID [None]: XL2HKL1bkDxeIEXAMPLE
+AWS Secret Access Key [None]: MCQNis0YSeFnQ0qgEZEheuqFeYJLJpxBSEXAMPLE
+Default region name [None]: 
+Default output format [None]:
+```
+
+Finally, you can interact with the Minio server using the AWS CLI:
+
+```bash
+$ export AWS_PROFILE=minio
+$ aws --endpoint-url http://localhost:9000 s3 ls
+$ aws --endpoint-url http://localhost:9000 s3 mb s3://test-bucket
+$ aws --endpoint-url http://localhost:9000 s3 cp /etc/os-release s3://test-bucket
+$ aws --endpoint-url http://localhost:9000 s3 ls s3://test-bucket
+```

--- a/quadlet/minio-prometheus/README.md
+++ b/quadlet/minio-prometheus/README.md
@@ -13,7 +13,6 @@ To run this example, you can move the files in this directory to your `~/.config
 
 ```bash
 $ systemctl --user daemon-reload
-$ systemctl --user start prometheus.service
 $ systemctl --user start minio.service
 $ xdg-open http://localhost:9001
 ```

--- a/quadlet/minio-prometheus/minio.container
+++ b/quadlet/minio-prometheus/minio.container
@@ -1,6 +1,7 @@
 [Unit]
 Description=A minio server contaienr for local S3 compatible storage
-After=local-fs.target network-online.target
+After=local-fs.target network-online.target prometheus.service
+Requires=prometheus.service
 
 [Container]
 Image=docker.io/minio/minio:latest

--- a/quadlet/minio-prometheus/minio.container
+++ b/quadlet/minio-prometheus/minio.container
@@ -4,12 +4,13 @@ After=local-fs.target network-online.target prometheus.service
 Requires=prometheus.service
 
 [Container]
+ContainerName=minio
 Image=docker.io/minio/minio:latest
 Exec=server --console-address ":9001"
 Environment=MINIO_ROOT_USER=admin
 Environment=MINIO_ROOT_PASSWORD=password
 Environment=MINIO_VOLUMES=/data
-Environment=MINIO_PROMETHEUS_URL='http://systemd-prometheus:9090'
+Environment=MINIO_PROMETHEUS_URL='http://prometheus:9090'
 Environment=MINIO_PROMETHEUS_AUTH_TYPE='public'
 Environment=MINIO_PROMETHEUS_JOB_ID='minio-job'
 Network=bridge

--- a/quadlet/minio-prometheus/minio.container
+++ b/quadlet/minio-prometheus/minio.container
@@ -1,0 +1,26 @@
+[Unit]
+Description=A minio server contaienr for local S3 compatible storage
+After=local-fs.target network-online.target prometheus-network.service
+Requires=prometheus-network.service
+
+[Container]
+Image=docker.io/minio/minio:latest
+Exec=server --console-address ":9001"
+Environment=MINIO_ROOT_USER=admin
+Environment=MINIO_ROOT_PASSWORD=password
+Environment=MINIO_VOLUMES=/data
+Environment=MINIO_PROMETHEUS_URL='http://systemd-prometheus:9090'
+Environment=MINIO_PROMETHEUS_AUTH_TYPE='public'
+Environment=MINIO_PROMETHEUS_JOB_ID='minio-job'
+Network=bridge
+Network=prometheus
+PublishPort=9000:9000
+PublishPort=9001:9001
+Volume=%h/.local/share/minio-data:/data:Z
+
+[Service]
+TimeoutStartSec=900
+ExecStartPre=-mkdir -p %h/.local/share/minio-data
+
+[Install]
+WantedBy=multi-user.target

--- a/quadlet/minio-prometheus/minio.container
+++ b/quadlet/minio-prometheus/minio.container
@@ -1,7 +1,6 @@
 [Unit]
 Description=A minio server contaienr for local S3 compatible storage
-After=local-fs.target network-online.target prometheus-network.service
-Requires=prometheus-network.service
+After=local-fs.target network-online.target
 
 [Container]
 Image=docker.io/minio/minio:latest
@@ -13,7 +12,7 @@ Environment=MINIO_PROMETHEUS_URL='http://systemd-prometheus:9090'
 Environment=MINIO_PROMETHEUS_AUTH_TYPE='public'
 Environment=MINIO_PROMETHEUS_JOB_ID='minio-job'
 Network=bridge
-Network=prometheus
+Network=prometheus.network
 PublishPort=9000:9000
 PublishPort=9001:9001
 Volume=%h/.local/share/minio-data:/data:Z

--- a/quadlet/minio-prometheus/minio.container
+++ b/quadlet/minio-prometheus/minio.container
@@ -1,5 +1,5 @@
 [Unit]
-Description=A minio server contaienr for local S3 compatible storage
+Description=A minio server container for local S3 compatible storage
 After=local-fs.target network-online.target prometheus.service
 Requires=prometheus.service
 
@@ -13,8 +13,7 @@ Environment=MINIO_VOLUMES=/data
 Environment=MINIO_PROMETHEUS_URL='http://prometheus:9090'
 Environment=MINIO_PROMETHEUS_AUTH_TYPE='public'
 Environment=MINIO_PROMETHEUS_JOB_ID='minio-job'
-Network=bridge
-Network=prometheus.network
+Network=minio.network
 PublishPort=9000:9000
 PublishPort=9001:9001
 Volume=%h/.local/share/minio-data:/data:Z

--- a/quadlet/minio-prometheus/minio.network
+++ b/quadlet/minio-prometheus/minio.network
@@ -1,0 +1,2 @@
+[Network]
+NetworkName=minio

--- a/quadlet/minio-prometheus/prometheus.container
+++ b/quadlet/minio-prometheus/prometheus.container
@@ -3,6 +3,7 @@ Description=A Prometheus container for collecting metrics
 After=local-fs.target network-online.target
 
 [Container]
+ContainerName=prometheus
 Image=docker.io/prom/prometheus:latest
 Network=bridge
 Network=prometheus.network

--- a/quadlet/minio-prometheus/prometheus.container
+++ b/quadlet/minio-prometheus/prometheus.container
@@ -1,0 +1,17 @@
+[Unit]
+Description=A Prometheus container for collecting metrics
+After=local-fs.target network-online.target prometheus-network.service
+Requires=prometheus-network.service
+
+[Container]
+Image=docker.io/prom/prometheus:latest
+Network=bridge
+Network=prometheus
+PublishPort=9090:9090
+Volume=./_config/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+
+[Service]
+TimeoutStartSec=900
+
+[Install]
+WantedBy=multi-user.target

--- a/quadlet/minio-prometheus/prometheus.container
+++ b/quadlet/minio-prometheus/prometheus.container
@@ -8,7 +8,7 @@ Image=docker.io/prom/prometheus:latest
 Network=bridge
 Network=prometheus
 PublishPort=9090:9090
-Volume=./_config/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+Volume=./prometheus.yml:/etc/prometheus/prometheus.yml:ro
 
 [Service]
 TimeoutStartSec=900

--- a/quadlet/minio-prometheus/prometheus.container
+++ b/quadlet/minio-prometheus/prometheus.container
@@ -8,7 +8,7 @@ Image=docker.io/prom/prometheus:latest
 Network=bridge
 Network=prometheus.network
 PublishPort=9090:9090
-Volume=./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+Volume=./prometheus.yml:/etc/prometheus/prometheus.yml:Z
 
 [Service]
 TimeoutStartSec=900

--- a/quadlet/minio-prometheus/prometheus.container
+++ b/quadlet/minio-prometheus/prometheus.container
@@ -7,7 +7,7 @@ ContainerName=prometheus
 Image=docker.io/prom/prometheus:latest
 Network=minio.network
 PublishPort=9090:9090
-Volume=./prometheus.yml:/etc/prometheus/prometheus.yml:Z
+Volume=./prometheus.yml:/etc/prometheus/prometheus.yml:ro,Z
 
 [Service]
 TimeoutStartSec=900

--- a/quadlet/minio-prometheus/prometheus.container
+++ b/quadlet/minio-prometheus/prometheus.container
@@ -1,12 +1,11 @@
 [Unit]
 Description=A Prometheus container for collecting metrics
-After=local-fs.target network-online.target prometheus-network.service
-Requires=prometheus-network.service
+After=local-fs.target network-online.target
 
 [Container]
 Image=docker.io/prom/prometheus:latest
 Network=bridge
-Network=prometheus
+Network=prometheus.network
 PublishPort=9090:9090
 Volume=./prometheus.yml:/etc/prometheus/prometheus.yml:ro
 

--- a/quadlet/minio-prometheus/prometheus.container
+++ b/quadlet/minio-prometheus/prometheus.container
@@ -5,8 +5,7 @@ After=local-fs.target network-online.target
 [Container]
 ContainerName=prometheus
 Image=docker.io/prom/prometheus:latest
-Network=bridge
-Network=prometheus.network
+Network=minio.network
 PublishPort=9090:9090
 Volume=./prometheus.yml:/etc/prometheus/prometheus.yml:Z
 

--- a/quadlet/minio-prometheus/prometheus.network
+++ b/quadlet/minio-prometheus/prometheus.network
@@ -1,3 +1,0 @@
-[Network]
-NetworkName=prometheus
-Internal=true

--- a/quadlet/minio-prometheus/prometheus.network
+++ b/quadlet/minio-prometheus/prometheus.network
@@ -1,0 +1,3 @@
+[Network]
+NetworkName=prometheus
+Internal=true

--- a/quadlet/minio-prometheus/prometheus.yml
+++ b/quadlet/minio-prometheus/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 5s
+  evaluation_interval: 5s
+  
+scrape_configs:
+  - job_name: minio-job
+    metrics_path: /minio/prometheus/metrics
+    scheme: http
+    static_configs:
+      - targets: ['systemd-minio:9000']

--- a/quadlet/minio-prometheus/prometheus.yml
+++ b/quadlet/minio-prometheus/prometheus.yml
@@ -7,4 +7,4 @@ scrape_configs:
     metrics_path: /minio/prometheus/metrics
     scheme: http
     static_configs:
-      - targets: ['systemd-minio:9000']
+      - targets: ['minio:9000']


### PR DESCRIPTION
Creates a sample Quadlet configuration that spins up minio and prometheus as a user-scoped systemd service.  
There is an internal network for cross-container communication, and the required ports are being exposed to the host (but not to other hosts on the network).

Also included instructions on how to deploy this sample, including storing a file with the AWS CLI.

I believe these are some needed examples of using multiple containers together with container DNS networking and exposing multiple ports.

If I am not following conventions or best practices, please let me know and I'd be happy to change it.