### PR TITLE
Add sample Valkey Quadlet

### DIFF
--- a/quadlet/valkey/README.md
+++ b/quadlet/valkey/README.md
@@ -1,0 +1,27 @@
+# Valkey
+
+> This Quadlet can be ran in a rootless container.
+
+[Valkey](https://valkey.io/) is an open source (BSD) high-performance key/value datastore that supports a variety workloads such as caching, message queues, and can act as a primary database. Valkey can run as either a standalone daemon or in a cluster, with options for replication and high availability.
+
+Since this Quadlet is a single container, it is not recommended for production use. For production use, you should run Valkey in a cluster by following the [Valkey documentation](https://valkey.io/docs/).
+
+Valkey does not currently publish a `:latest` or `:stable` tag, so the quadlet contains the hard-coded version `7.2`. If you would like to use a different version, you can modify the image tag inside the `valkey.container` file.
+
+## Usage
+
+This Quadlet requires no special permissions to run.
+
+To setup the Valkey Quadlet, you can paste the `valkey.container` and `valkey.volume` files into any of the following directories:
+
+- `$HOME/.config/containers/systemd/`
+- `/etc/containers/systemd/users/`
+
+You can start the Valkey server with the following command, as a regular user:
+
+```bash
+$ systemctl --user daemon-reload
+$ systemctl --user start valkey.service
+```
+
+You are now ready to connect your application to the Valkey server at localhost:6379.

--- a/quadlet/valkey/valkey.container
+++ b/quadlet/valkey/valkey.container
@@ -1,0 +1,18 @@
+[Unit]
+Description=A Valkey development container
+Wants=network-online.target
+After=network-online.target
+
+[Container]
+Image=docker.io/valkey/valkey:7.2
+AutoUpdate=registry
+ContainerName=valkey
+PublishPort=6379:6379
+Volume=valkey.volume:/data:Z
+
+[Service]
+# Pulling the image from the registry can take a while
+TimeoutStartSec=900
+
+[Install]
+WantedBy=multi-user.target

--- a/quadlet/valkey/valkey.volume
+++ b/quadlet/valkey/valkey.volume
@@ -1,0 +1,2 @@
+[Volume]
+VolumeName=valkey-data


### PR DESCRIPTION
This PR adds a sample Valkey development quadlet.  I thought it would be cool to demonstrate how to host this newly-forked open source service with Podman and Systemd.

As with most of these, it's not recommended for production usage since it's a single node cluster, and does not include auth (although blog posts on how to use these distributed apps in Quadlets across different systems would be useful to see how this can be achieved).

The Quadlet does **not** start on boot, and requires the user to manually start the service.

I have signed off all commits in this PR, and squashed them down into a single one.

I'm hoping this is a simple one to review, since it's just a container, volume and README - compared to my others, which were multiple services talking together.