### PR TITLE
Create localstack quadlet

### DIFF
--- a/quadlet/localstack/README.md
+++ b/quadlet/localstack/README.md
@@ -1,0 +1,26 @@
+# Localstack
+
+[Localstack](https://www.localstack.cloud/) is a service which allows you to emulate AWS services locally.  Some of the services are free and open-source, while others require a license. Some of the notable services which are open-source are S3, DynamoDB and Lambda.
+
+This quadlet runs Localstack as a rootless container, and mounts a volume to store the data.  It also mounts the Podman socket to allow the container to start other containers.  This is a requirement for running Lambda functions.
+
+## Installation
+
+To install the Localstack quadlet to your user's systemd services, copy the `localstack.container` and `localstack.volume` files to any of the following directories:
+
+- `$HOME/.config/containers/systemd/`
+- `/etc/containers/systemd/users/`
+
+Once the files are in place, you can generate the systemd service files and execute the service:
+
+```bash
+$ systemctl --user daemon-reload
+$ systemctl --user start localstack
+```
+
+You are then able to call out to the local services using the AWS CLI or SDKs by pointing towards the localstack endpoint.
+
+```bash
+$ aws --endpoint-url=http://localhost:4566 s3 mb s3://mybucket
+$ aws --endpoint-url=http://localhost:4566 s3 ls
+```

--- a/quadlet/localstack/localstack.container
+++ b/quadlet/localstack/localstack.container
@@ -1,0 +1,22 @@
+[Unit]
+Description=A Localstack container for local development of AWS services
+Requires=podman.socket
+After=network-online.target podman.socket
+
+[Container]
+Image=docker.io/localstack/localstack:latest
+AutoUpdate=registry
+ContainerName=localstack
+Environment=DOCKER_SOCK=unix:///run/podman/podman.sock
+Environment=DOCKER_HOST=unix:///run/podman/podman.sock
+Environment=DOCKER_CMD=podman
+PublishPort=4566:4566
+PublishPort=4510-4559:4510-4559
+Volume=localstack.volume:/var/lib/localstack:Z
+Volume=/run/user/%G/podman/podman.sock:/run/podman/podman.sock:ro
+
+[Service]
+TimeoutStartSec=900
+
+[Install]
+WantedBy=multi-user.target

--- a/quadlet/localstack/localstack.volume
+++ b/quadlet/localstack/localstack.volume
@@ -1,0 +1,2 @@
+[Volume]
+VolumeName=localstack-data


### PR DESCRIPTION
Localstack is a development tool I frequently use to emulate AWS services locally.  This allows engineers to create for AWS without deploying any resources to the cloud.

This quadlet is a rootless container, storing data to the volume and speaking to Podman through a readonly mount (unsure how exactly this works, but it does).  

This may be useful in the appstore repo since it's not a straightforward volume mount.  You must find out the user GID in order to mount the Podman socket and set environment variables to tell Localstack to use the Podman socket.