### PR TITLE
Create quadlet configuration for Zot Registry

### DIFF
--- a/quadlet/zot-registry/README.md
+++ b/quadlet/zot-registry/README.md
@@ -1,0 +1,52 @@
+# Zot Registry
+
+[Zot Registry](https://zotregistry.dev/) is an open-source CNCF sandbox project which allows you to store and retrieve OCI images. It is a lightweight, but powerful alternative to the Docker registry which has built-in features such as pull-through cache, image scanning and signing.
+
+This quadlet runs Zot Registry as a rootless container, and mounts a volume to store the OCI images. It does not contain any authentication, so is not recommended for production use.
+
+## Installation
+
+To install the Zot Registry quadlet to your user's systemd services, copy the `zot-registry.container`, `zot-registry.volume` and `config.yaml` files to either of the following directories:
+
+- `$HOME/.config/containers/systemd/`
+- `/etc/containers/systemd/users/`
+
+Once the files are in place, you can generate the systemd service files and execute the service:
+
+```bash
+$ systemctl --user daemon-reload
+$ systemctl --user start zot-registry
+
+# Optional: enable the service to start on boot
+$ systemctl --user enable zot-registry
+```
+
+## Usage
+
+The configuration file `config.yaml` contains all the necessary configuration for the registry.  This includes pull-through cache for all containers with the `ghcr.io/containers/` prefix.  This can be updated to include other prefixes as required.
+
+Since this registry does not use HTTPS, you will need to add a configuration file to `/etc/containers/registries.conf.d/zot-registry.conf`.  Otherwise you will receive an error when trying to pull or push images:
+
+```bash
+[[registry]]
+location = "localhost:5000"
+insecure = true
+```
+
+Once you have added that, you are able to push images to the registry using the `podman` command:
+
+```bash
+$ podman pull quay.io/fedora/fedora:latest
+$ podman tag quay.io/fedora/fedora:latest localhost:5000/my-library/fedora:latest
+$ podman push localhost:5000/my-library/fedora:latest
+```
+
+You can then pull the image from the registry or use it as part of a `Containerfile` (`Dockerfile`):
+
+```bash
+$ podman pull localhost:5000/my-library/fedora:latest
+$ cat <<EOF > Containerfile
+FROM localhost:5000/my-library/fedora:latest
+CMD echo "Hello, World!"
+EOF
+```

--- a/quadlet/zot-registry/config.yaml
+++ b/quadlet/zot-registry/config.yaml
@@ -1,0 +1,21 @@
+distspecversion: 1.0.1
+http:
+  address: 0.0.0.0
+  port: 5000
+storage:
+  rootdirectory: /var/lib/zot/data
+extensions:
+  search:
+    enable: true
+    cve:
+      updateInterval: 12h
+  ui:
+    enable: true
+  sync:
+    registries:
+      # Pull-through cache for ghcr.io/containers images
+      - urls:
+        - https://ghcr.io/containers
+        onDemand: true
+        content:
+          - prefix: "containers/**"

--- a/quadlet/zot-registry/zot-registry.container
+++ b/quadlet/zot-registry/zot-registry.container
@@ -1,0 +1,18 @@
+[Unit]
+Description=A Zot registry container
+After=network-online.target
+
+[Container]
+Image=ghcr.io/project-zot/zot-linux-amd64:latest
+AutoUpdate=registry
+ContainerName=zot-registry
+Exec=serve /etc/zot/config.yaml
+Volume=zot-registry.volume:/var/lib/zot/data:Z
+Volume=./config.yaml:/etc/zot/config.yaml:Z
+PublishPort=5000:5000
+
+[Service]
+TimeoutStartSec=900
+
+[Install]
+WantedBy=multi-user.target

--- a/quadlet/zot-registry/zot-registry.volume
+++ b/quadlet/zot-registry/zot-registry.volume
@@ -1,0 +1,2 @@
+[Volume]
+VolumeName=zot-registry-data


### PR DESCRIPTION
Add a quadlet for hosting Zot Registry locally with pull-through cache.

Yes, I know it would have been good to use Quay instead, but it's just very heavy and has far more dependencies compared to Zot.