### PR TITLE
Create quadlet configuration for Ollama

### DIFF
--- a/quadlet/ollama/README.md
+++ b/quadlet/ollama/README.md
@@ -1,0 +1,28 @@
+# Ollama & Open WebUI
+
+Ollama is an open-source project which provides an easy interface for running and interacting with LLMs (Large Language Models).
+One way to use Ollama is to access it through the Open WebUI, which provides a web interface which resembles the ChatGPT site.
+
+This quadlet runs Ollama as a rootless container, however runs without SELinux confinement.  It mounts a volume to store the data and the models so they can be persisted between restarts.  It also contains the required configuration for NVIDIA CUDA and ROCm support, so you can benefit from GPU acceleration.
+
+Unfortunately the Open WebUI does not support defining default credentials, so users must first sign-up when accessing the site for the first time.
+
+## Installation
+
+To install the Ollama quadlet to your user's systemd services, copy the `ollama.network`, `ollama.volume`, `ollama-webui.volume`, `ollama-webui.container` and `ollama.container` files to either of the following directories:
+
+- `$HOME/.config/containers/systemd/`
+- `/etc/containers/systemd/users/`
+
+If you wish to use GPU acceleration with CUDA or ROCm, you should also copy over the respective `.conf` files inside the `ollama.container.d` directory.  These options will be automatically merged with the container configuration when the service is generated.
+
+## Usage
+
+To start the Ollama and Open WebUI services, you can generate the systemd service files and execute the services:
+
+```bash
+$ systemctl --user daemon-reload
+$ systemctl --user start ollama-web
+```
+
+This will bring up the Ollama service and the Open WebUI service.  You can then access the Open WebUI by navigating to `http://localhost:8080` in your web browser.

--- a/quadlet/ollama/ollama-web.container
+++ b/quadlet/ollama/ollama-web.container
@@ -1,0 +1,24 @@
+[Unit]
+Description=An Ollama WebUI container
+After=network-online.target ollama.service
+Requires=ollama.service
+
+[Container]
+Image=ghcr.io/open-webui/open-webui:latest
+AutoUpdate=registry
+ContainerName=ollama-web
+Environment=OLLAMA_BASE_URL=http://ollama:11434
+Environment=DEFAULT_USER_ROLE=admin
+# Open WebUI does not allow access without a user account, nor does it allow
+# account creation via environment variables.  The user must create the account
+# on the first run.
+Environment=ENABLE_SIGNUP=true
+Network=ollama.network
+PublishPort=8080:8080
+Volume=ollama-web:/app/backend/data:Z
+
+[Service]
+TimeoutStartSec=900
+
+[Install]
+WantedBy=multi-user.target

--- a/quadlet/ollama/ollama-web.volume
+++ b/quadlet/ollama/ollama-web.volume
@@ -1,0 +1,2 @@
+[Volume]
+VolumeName=ollama-web-data

--- a/quadlet/ollama/ollama.container
+++ b/quadlet/ollama/ollama.container
@@ -1,0 +1,17 @@
+[Unit]
+Description=An ollama container
+After=network-online.target
+
+[Container]
+Image=docker.io/ollama/ollama:latest
+AutoUpdate=registry
+ContainerName=ollama
+Network=ollama.network
+Volume=ollama.volume:/root/.ollama
+PublishPort=11434:11434
+
+[Service]
+TimeoutStartSec=900
+
+[Install]
+WantedBy=multi-user.target

--- a/quadlet/ollama/ollama.container.d/nvidia.conf
+++ b/quadlet/ollama/ollama.container.d/nvidia.conf
@@ -1,0 +1,3 @@
+[Container]
+AddDevice=nvidia.com/gpu=all
+SecurityLabelDisable=true

--- a/quadlet/ollama/ollama.container.d/rocm.conf
+++ b/quadlet/ollama/ollama.container.d/rocm.conf
@@ -1,0 +1,5 @@
+[Container]
+Image=docker.io/ollama/ollama:rocm
+AddDevice=/dev/dri
+AddDevice=/dev/kfd
+SecurityLabelDisable=true

--- a/quadlet/ollama/ollama.network
+++ b/quadlet/ollama/ollama.network
@@ -1,0 +1,2 @@
+[Network]
+NetworkName=ollama

--- a/quadlet/ollama/ollama.volume
+++ b/quadlet/ollama/ollama.volume
@@ -1,0 +1,2 @@
+[Volume]
+VolumeName=ollama-data


### PR DESCRIPTION
I wanted to provide the Ollama quadlet definitions because it shows how we can attach GPUs to the quadlets, plus changing the selinux configuration and using the `.d` directory for switching between Nvidia and ROCm.