### PR TITLE
add caddy graceful reloads to bsky_pds

### DIFF
--- a/quadlet/bluesky_pds/caddy.container
+++ b/quadlet/bluesky_pds/caddy.container
@@ -14,6 +14,7 @@ PublishPort=443:443
 PublishPort=443:443/udp
 Network=pds.network
 UserNS=auto:size=28
+ReloadCmd=caddy reload -c /etc/caddy/Caddyfile
 
 [Service]
 Restart=on-failure


### PR DESCRIPTION
Enable systemctl reload to perform a graceful caddy reload.
